### PR TITLE
Handle missing inkscape.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,21 @@ Simple magic functions that adds support for dropping shadows in diagram
 
 pip install git+https://github.com/sursingh/dotmagic.git
 
+This has a dependency on [inkscape](https://inkscape.org/). `inkscape`
+needs to be installed for supporting rendering to `png`. SVG rendering should
+work out of the box.
+
 ## Usage
 
 ```
-%%dot -psK <layout>
+%%dot -prsK <layout>
  -p: convert image to png (default SVG)
+ -r: return raw svg file
  -s: drop shadows
  -K <layout>: Select the layout
     dot(default), neato, twopi, circle, fdpm sfdp
 
-%dotstr -psK <layout> <dotstr>
+%dotstr -prsK <layout> <dotstr>
 
 ```
 
@@ -35,7 +40,7 @@ color='lightblue'
 
 
 ```python
-%%dot -p
+%%dot
 digraph {
     node [color="${color}" style="${style}"]
     a -> {b c}
@@ -52,7 +57,7 @@ g = '''digraph {
    node [color="${color}" style="${style}"]
     a -> {b c} 
 }'''
-%dotstr -p g
+%dotstr g
 ```
 
 
@@ -63,7 +68,7 @@ g = '''digraph {
 
 
 ```python
-%%dot -sp
+%%dot -s
 digraph {
     node [color="${color}" style="${style}"]
     a -> {b c}
@@ -78,7 +83,7 @@ digraph {
 
 
 ```python
-%%dot -spK neato
+%%dot -sK neato
 digraph {
     node [color="${color}" style="${style}"]
     a -> {b c}

--- a/dotmagic/dotmagic.py
+++ b/dotmagic/dotmagic.py
@@ -4,6 +4,7 @@
 from subprocess import Popen, PIPE
 import string
 import tempfile
+from shutil import which
 from pkg_resources import resource_filename
 from IPython.display import SVG, Image
 from IPython.core.magic import (
@@ -46,6 +47,7 @@ class DotMagics(Magics):
         super().__init__(shell, **kwargs)
         self._opts = 'prsK:'
         self._tmpdir = tempfile.mkdtemp()
+        self._inkscape = which("inkscape")
 
 
     def _run_graphviz(self, s, output='svg', layout='dot'):
@@ -87,8 +89,12 @@ class DotMagics(Magics):
             cmd = self._drop_shadow(cmd)
 
         if 'p' in opts:
-            cmd = self._svg_to_png(cmd)
-            image_type = Image
+            if self._inkscape is not None:
+                cmd = self._svg_to_png(cmd)
+                image_type = Image
+            else:
+                print("`inkscape` not found")
+                print("Falling back to PNG rendering") 
 
         if 'r' in opts:
             return cmd.read()


### PR DESCRIPTION
* check if inkscape is installed, else print an error
* fallback to SVG rendering if inkscape is not available
* updated README to specify the dependency on `inkscape`

Fixes #1 